### PR TITLE
Add clang-format CI job, apply formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 80
+AllowShortBlocksOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Attach
+DerivePointerAlignment: false
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 1

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -3,8 +3,23 @@ name: Arduino Library CI
 on: [pull_request, push, repository_dispatch]
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v4
+      with:
+        repository: adafruit/ci-arduino
+        path: ci
+    - name: clang-format
+      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
+
   build:
     runs-on: ubuntu-latest
+    needs: clang-format
     
     steps:
     - uses: actions/setup-python@v4
@@ -21,9 +36,6 @@ jobs:
 
     - name: test platforms
       run: python3 ci/build_platform.py cpx
-
-    - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
 
     - name: doxygen
       env:

--- a/Adafruit_CompositeVideo.cpp
+++ b/Adafruit_CompositeVideo.cpp
@@ -49,7 +49,6 @@
 // Allowing space for the sync and blank voltages, there are ~220 available
 // brightness levels (not 256).  GFX functions take care of brightness
 // scaling, so use 0 for black and 255 for white as normal.
-//#define DAC_MAX 1023           ///< Use 1.0 V DAC analog ref
 #define DAC_MAX (1023 * 10 / 33) ///< Use subset of 3.3V DAC
 
 // Currently only one video format & resolution is supported, and maybe
@@ -104,43 +103,38 @@ boolean Adafruit_CompositeVideo::begin(void) {
   // Big allocation --------------------------------------------------------
 
   // DMA descriptor list MUST be 128-bit (16 byte) aligned!
-  if (!(descriptor = (DmacDescriptor *)memalign(
+  if (!(descriptor = (DmacDescriptor*)memalign(
             16,
             sizeof(DmacDescriptor) * videoSpec[mode].numDescriptors +
                 sizeof(uint16_t) * videoSpec[mode].rowPixelClocks * HEIGHT)))
     return false;
 
   // Frame buffer follows descriptor list.
-  frameBuffer = (uint16_t *)&descriptor[videoSpec[mode].numDescriptors];
+  frameBuffer = (uint16_t*)&descriptor[videoSpec[mode].numDescriptors];
 
   // Timer init ------------------------------------------------------------
   // TC5 is used; this will knock out the Tone library
 
   GCLK->CLKCTRL.reg = (uint16_t)(GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 |
                                  GCLK_CLKCTRL_ID(GCM_TC4_TC5));
-  while (GCLK->STATUS.bit.SYNCBUSY == 1)
-    ;
+  while (GCLK->STATUS.bit.SYNCBUSY == 1) {}
 
   TC5->COUNT16.CTRLA.reg &= ~TC_CTRLA_ENABLE; // Disable TCx to config it
-  while (TC5->COUNT16.STATUS.bit.SYNCBUSY)
-    ;
+  while (TC5->COUNT16.STATUS.bit.SYNCBUSY) {}
 
   TC5->COUNT16.CTRLA.reg =     // Configure timer counter
       TC_CTRLA_MODE_COUNT16 |  // 16-bit counter mode
       TC_CTRLA_WAVEGEN_MFRQ |  // Match Frequency mode
       TC_CTRLA_PRESCALER_DIV1; // 1:1 Prescale
-  while (TC5->COUNT16.STATUS.bit.SYNCBUSY)
-    ;
+  while (TC5->COUNT16.STATUS.bit.SYNCBUSY) {}
 
   TC5->COUNT16.CC[0].reg = videoSpec[mode].timerPeriod;
-  while (TC5->COUNT16.STATUS.bit.SYNCBUSY)
-    ;
+  while (TC5->COUNT16.STATUS.bit.SYNCBUSY) {}
 
   TC5->COUNT16.CTRLA.reg |= TC_CTRLA_ENABLE; // Re-enable TCx
-  while (TC5->COUNT16.STATUS.bit.SYNCBUSY)
-    ;
+  while (TC5->COUNT16.STATUS.bit.SYNCBUSY) {}
 
-    // DAC INIT --------------------------------------------------------------
+  // DAC INIT --------------------------------------------------------------
 
 #ifdef ADAFRUIT_CIRCUITPLAYGROUND_M0
   pinMode(11, OUTPUT);
@@ -150,8 +144,7 @@ boolean Adafruit_CompositeVideo::begin(void) {
   analogWrite(A0, 512);      // ain't nobody got time for that!
 #if DAC_MAX == 1023
   DAC->CTRLB.bit.REFSEL = 0; // VMAX = 1.0V
-  while (DAC->STATUS.bit.SYNCBUSY)
-    ;
+  while (DAC->STATUS.bit.SYNCBUSY) {}
 #endif
 
   // DMA transfer job is NOT started here!  That's done in subclass
@@ -168,20 +161,20 @@ void Adafruit_CompositeVideo::drawPixel(int16_t x, int16_t y, uint16_t color) {
 
   int16_t t;
   switch (rotation) {
-  case 1:
-    t = x;
-    x = WIDTH - 1 - y;
-    y = t;
-    break;
-  case 2:
-    x = WIDTH - 1 - x;
-    y = HEIGHT - 1 - y;
-    break;
-  case 3:
-    t = x;
-    x = y;
-    y = HEIGHT - 1 - t;
-    break;
+    case 1:
+      t = x;
+      x = WIDTH - 1 - y;
+      y = t;
+      break;
+    case 2:
+      x = WIDTH - 1 - x;
+      y = HEIGHT - 1 - y;
+      break;
+    case 3:
+      t = x;
+      x = y;
+      y = HEIGHT - 1 - t;
+      break;
   }
 
   frameBuffer[y * videoSpec[mode].rowPixelClocks + x +
@@ -194,19 +187,19 @@ void Adafruit_CompositeVideo::drawPixel(int16_t x, int16_t y, uint16_t color) {
 // 25 and 50 in this case refer to the total number of pixel clocks per
 // line, which includes horizontal sync and overscan.  The available drawable
 // raster size is narrower than this (40 pixels).
-#define NTSC_EQ_HALFLINE25                                                     \
-  NS, NS, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_,  \
+#define NTSC_EQ_HALFLINE25                                                    \
+  NS, NS, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, \
       N_, N_, N_, N_, N_, N_ ///< One-half vsync scanline
-#define NTSC_SERRATION_HALFLINE25                                              \
-  NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS,  \
+#define NTSC_SERRATION_HALFLINE25                                             \
+  NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, NS, \
       NS, NS, NS, N_, N_, N_ ///< Different one-half vsync scanline
-#define NTSC_BLANK_LINE50                                                      \
-  NS, NS, NS, NS, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_,  \
-      N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_,  \
+#define NTSC_BLANK_LINE50                                                     \
+  NS, NS, NS, NS, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, \
+      N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, \
       N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_, N_ ///< Full line blank
-#define NTSC_EMPTY_LINE50                                                      \
-  NS, NS, NS, NS, N_, N_, N_, N_, N_, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK,  \
-      NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK,  \
+#define NTSC_EMPTY_LINE50                                                     \
+  NS, NS, NS, NS, N_, N_, N_, N_, N_, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, \
+      NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, \
       NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, NK, N_ ///< Full line black
 
 // NTSC sync (NS), blank (N_), black (NK) and white (NW) levels
@@ -310,7 +303,7 @@ boolean Adafruit_NTSC40x24::begin(void) {
   // is 50 words (2 bytes ea) * 24 lines = 2400 bytes.
   // 8720 + 1 + 2400 = 11,121 bytes!
 
-  DmacDescriptor *desc;
+  DmacDescriptor* desc;
 
   for (uint16_t i = 0; i < videoSpec[mode].numDescriptors; i++) {
     desc = &descriptor[i];
@@ -399,7 +392,11 @@ void Adafruit_NTSC40x24::clear(void) {
 }
 
 // Hacky stuff, don't use this
-void Adafruit_NTSC40x24::setBlank(uint8_t value) { vBlank = value; }
+void Adafruit_NTSC40x24::setBlank(uint8_t value) {
+  vBlank = value;
+}
 
 // Ditto
-uint8_t Adafruit_NTSC40x24::getBlank(void) { return vBlank; }
+uint8_t Adafruit_NTSC40x24::getBlank(void) {
+  return vBlank;
+}

--- a/Adafruit_CompositeVideo.h
+++ b/Adafruit_CompositeVideo.h
@@ -28,7 +28,7 @@
  *         providing bitmapped low-resolution grayscale graphics.
  */
 class Adafruit_CompositeVideo : public Adafruit_GFX {
-public:
+ public:
   /**
    * @brief  Construct a new Adafruit_CompositeVideo object.
    * @param  mode    Video mode, must be 0 (NTSC, others might be added
@@ -52,11 +52,11 @@ public:
    */
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 
-protected:
+ protected:
   const uint8_t mode;         ///< Video mode, only MODE_NTSC40x24 right now
   Adafruit_ZeroDMA dma;       ///< SAMD DMA object
-  DmacDescriptor *descriptor; ///< DMA descriptor list
-  uint16_t *frameBuffer;      ///< Pixel data
+  DmacDescriptor* descriptor; ///< DMA descriptor list
+  uint16_t* frameBuffer;      ///< Pixel data
 };
 
 /**
@@ -64,7 +64,7 @@ protected:
            Adafruit_CompositeVideo.
  */
 class Adafruit_NTSC40x24 : public Adafruit_CompositeVideo {
-public:
+ public:
   /**
    * @brief Construct a new Adafruit_NTSC40x24 object.
    */


### PR DESCRIPTION
This PR adds proper clang-format CI support:

- Add new `.clang-format` config file  
- Split workflow: `clang-format` job runs first, build depends on it
- Remove inline clang step from build job (now in separate job)
- Apply clang-format to all source files
- Convert `while();` empty loops to `while(){}` for cross-version stability

Tested locally with both clang-format 18 and 19.

cc @ladyada